### PR TITLE
removed web group from nomad file, added quotes to service name

### DIFF
--- a/dp-sessions-api.nomad
+++ b/dp-sessions-api.nomad
@@ -11,70 +11,6 @@ job "dp-sessions-api" {
     auto_revert      = true
   }
 
-  group "web" {
-    count = "{{WEB_TASK_COUNT}}"
-
-    constraint {
-      attribute = "${node.class}"
-      value     = "web"
-    }
-
-    restart {
-      attempts = 3
-      delay    = "15s"
-      interval = "1m"
-      mode     = "delay"
-    }
-
-    task "dp-sessions-api-web" {
-      driver = "docker"
-
-      artifact {
-        source = "s3::https://s3-eu-west-1.amazonaws.com/{{DEPLOYMENT_BUCKET}}/dp-sessions-api/{{PROFILE}}/{{RELEASE}}.tar.gz"
-      }
-
-      config {
-        command = "${NOMAD_TASK_DIR}/start-task"
-
-        args = ["./dp-sessions-api"]
-
-        image = "{{ECR_URL}}:concourse-{{REVISION}}"
-
-      }
-
-      service {
-        name = "dp-sessions-api"
-        port = "http"
-        tags = ["web"]
-
-        check {
-          type     = "http"
-          path     = "/health"
-          interval = "10s"
-          timeout  = "2s"
-        }
-      }
-
-      resources {
-        cpu    = "{{WEB_RESOURCE_CPU}}"
-        memory = "{{WEB_RESOURCE_MEM}}"
-
-        network {
-          port "http" {}
-        }
-      }
-
-      template {
-        source      = "${NOMAD_TASK_DIR}/vars-template"
-        destination = "${NOMAD_TASK_DIR}/vars"
-      }
-
-      vault {
-        policies = ["dp-sessions-api-web"]
-      }
-    }
-  }
-
   group "publishing" {
     count = "{{PUBLISHING_TASK_COUNT}}"
 
@@ -106,7 +42,7 @@ job "dp-sessions-api" {
       }
 
       service {
-        name = dp-sessions-api
+        name = "dp-sessions-api"
         port = "http"
         tags = ["publishing"]
 


### PR DESCRIPTION
Removed web group from .nomad as not required. 
Surrounded service name with quotes, missing from dp-cli project generation.