### PR TITLE
Removed pluralisation and updated session interface

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-
 	"github.com/ONSdigital/dp-authorisation/auth"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
@@ -23,10 +22,10 @@ func Setup(ctx context.Context, r *mux.Router, permissions AuthHandler) *API {
 		Router: r,
 	}
 
-	nopSess := &NOPSession{}
+	nopSession := &NOPSession{}
 	nopCache := &NOPCache{}
 
-	r.HandleFunc("/sessions", permissions.Require(create, CreateSessionHandlerFunc(nopSess, nopCache))).Methods("POST")
+	r.HandleFunc("/sessions", permissions.Require(create, CreateSessionHandlerFunc(nopSession, nopCache))).Methods("POST")
 	r.HandleFunc("/sessions/{ID}", GetByIDSessionHandlerFunc(nopCache, mux.Vars)).Methods("GET")
 	r.HandleFunc("/sessions", permissions.Require(delete, DeleteAllSessionsHandlerFunc(nopCache))).Methods("DELETE")
 	return api

--- a/api/api.go
+++ b/api/api.go
@@ -17,7 +17,7 @@ func Setup(ctx context.Context, r *mux.Router, permissions AuthHandler) *API {
 		Router: r,
 	}
 
-	nopSess := &NOPSessions{}
+	nopSess := &NOPSession{}
 	nopCache := &NOPCache{}
 	create := auth.Permissions{Create: true}
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -15,7 +15,7 @@ import (
 type GetVarsFunc func(r *http.Request) map[string]string
 
 // CreateSessionHandlerFunc returns a function that generates a session. Method = "POST"
-func CreateSessionHandlerFunc(sessions Sessions, cache Cache) http.HandlerFunc {
+func CreateSessionHandlerFunc(sess Session, cache Cache) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -31,7 +31,7 @@ func CreateSessionHandlerFunc(sessions Sessions, cache Cache) http.HandlerFunc {
 			return
 		}
 
-		sess, err := sessions.New(c.Email)
+		sess, err := sess.New(c.Email)
 		if err != nil {
 			writeErrorResponse(ctx, w, "failed to create session", err, http.StatusInternalServerError)
 			return
@@ -50,7 +50,7 @@ func CreateSessionHandlerFunc(sessions Sessions, cache Cache) http.HandlerFunc {
 
 		log.Event(ctx, "session added to cache", log.INFO)
 
-		sessJSON, err := sess.MarshalJSON()
+		sessJSON, err := s.MarshalJSON()
 		if err != nil {
 			writeErrorResponse(ctx, w, "failed to marshal session", err, http.StatusInternalServerError)
 			return

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -31,16 +31,10 @@ func CreateSessionHandlerFunc(sess Session, cache Cache) http.HandlerFunc {
 			return
 		}
 
-		sess, err := sess.New(c.Email)
+		s, err := sess.New(c.Email)
 		if err != nil {
 			writeErrorResponse(ctx, w, "failed to create session", err, http.StatusInternalServerError)
 			return
-		}
-
-		s := &session.Session{
-			ID:    sess.ID,
-			Email: sess.Email,
-			Start: sess.Start,
 		}
 
 		if err := cache.Set(s); err != nil {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -15,7 +15,7 @@ import (
 type GetVarsFunc func(r *http.Request) map[string]string
 
 // CreateSessionHandlerFunc returns a function that generates a session. Method = "POST"
-func CreateSessionHandlerFunc(updater Updater, cache Cache) http.HandlerFunc {
+func CreateSessionHandlerFunc(sessionUpdater SessionUpdater, cache Cache) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -31,7 +31,7 @@ func CreateSessionHandlerFunc(updater Updater, cache Cache) http.HandlerFunc {
 			return
 		}
 
-		s, err := updater.Update(c.Email)
+		s, err := sessionUpdater.Update(c.Email)
 		if err != nil {
 			writeErrorResponse(ctx, w, "failed to create session", err, http.StatusInternalServerError)
 			return

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCreateSessionHandlerFunc(t *testing.T) {
 	Convey("Given a valid request", t, func() {
-		mockSession := &apiMock.UpdaterMock{}
+		mockSession := &apiMock.SessionUpdaterMock{}
 		mockCache := &apiMock.CacheMock{}
 		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
@@ -37,7 +37,7 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 	Convey("Given a valid request", t, func() {
 		currentTime := time.Now()
-		mockSession := &apiMock.UpdaterMock{
+		mockSession := &apiMock.SessionUpdaterMock{
 			UpdateFunc: func(email string) (*session.Session, error) {
 				return &session.Session{
 					ID:    "1234",
@@ -81,7 +81,7 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 	})
 
 	Convey("Given a bad request", t, func() {
-		mockSession := &apiMock.UpdaterMock{}
+		mockSession := &apiMock.SessionUpdaterMock{}
 		mockCache := &apiMock.CacheMock{}
 		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
@@ -99,7 +99,7 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 	})
 
 	Convey("Given a bad request", t, func() {
-		mockSession := &apiMock.UpdaterMock{}
+		mockSession := &apiMock.SessionUpdaterMock{}
 		mockCache := &apiMock.CacheMock{}
 		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
@@ -120,7 +120,7 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 	})
 
 	Convey("Given a new session", t, func() {
-		mockSession := &apiMock.UpdaterMock{
+		mockSession := &apiMock.SessionUpdaterMock{
 			UpdateFunc: func(email string) (*session.Session, error) {
 				return nil, errors.New("unable to generate id")
 			},
@@ -146,7 +146,7 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 	Convey("Given a valid request", t, func() {
 		currentTime := time.Now()
-		mockSession := &apiMock.UpdaterMock{
+		mockSession := &apiMock.SessionUpdaterMock{
 			UpdateFunc: func(email string) (*session.Session, error) {
 				return &session.Session{
 					ID:    "1234",

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCreateSessionHandlerFunc(t *testing.T) {
 	Convey("Given a valid request", t, func() {
-		mockSession := &apiMock.SessionMock{}
+		mockSession := &apiMock.UpdaterMock{}
 		mockCache := &apiMock.CacheMock{}
 		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
@@ -30,15 +30,15 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusBadRequest)
-				So(mockSession.NewCalls(), ShouldHaveLength, 0)
+				So(mockSession.UpdateCalls(), ShouldHaveLength, 0)
 			})
 		})
 	})
 
 	Convey("Given a valid request", t, func() {
 		currentTime := time.Now()
-		mockSession := &apiMock.SessionMock{
-			NewFunc: func(email string) (*session.Session, error) {
+		mockSession := &apiMock.UpdaterMock{
+			UpdateFunc: func(email string) (*session.Session, error) {
 				return &session.Session{
 					ID:    "1234",
 					Email: email,
@@ -73,15 +73,15 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(resp.Body.String(), ShouldEqual, string(b))
 				So(resp.Code, ShouldEqual, 201)
-				So(mockSession.NewCalls(), ShouldHaveLength, 1)
-				So(mockSession.NewCalls()[0].Email, ShouldEqual, "test@test.com")
+				So(mockSession.UpdateCalls(), ShouldHaveLength, 1)
+				So(mockSession.UpdateCalls()[0].Email, ShouldEqual, "test@test.com")
 				So(mockCache.SetCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})
 
 	Convey("Given a bad request", t, func() {
-		mockSession := &apiMock.SessionMock{}
+		mockSession := &apiMock.UpdaterMock{}
 		mockCache := &apiMock.CacheMock{}
 		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
@@ -93,13 +93,13 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusBadRequest)
-				So(mockSession.NewCalls(), ShouldHaveLength, 0)
+				So(mockSession.UpdateCalls(), ShouldHaveLength, 0)
 			})
 		})
 	})
 
 	Convey("Given a bad request", t, func() {
-		mockSession := &apiMock.SessionMock{}
+		mockSession := &apiMock.UpdaterMock{}
 		mockCache := &apiMock.CacheMock{}
 		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
@@ -114,14 +114,14 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusBadRequest)
-				So(mockSession.NewCalls(), ShouldHaveLength, 0)
+				So(mockSession.UpdateCalls(), ShouldHaveLength, 0)
 			})
 		})
 	})
 
 	Convey("Given a new session", t, func() {
-		mockSession := &apiMock.SessionMock{
-			NewFunc: func(email string) (*session.Session, error) {
+		mockSession := &apiMock.UpdaterMock{
+			UpdateFunc: func(email string) (*session.Session, error) {
 				return nil, errors.New("unable to generate id")
 			},
 		}
@@ -139,15 +139,15 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
-				So(mockSession.NewCalls(), ShouldHaveLength, 1)
+				So(mockSession.UpdateCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})
 
 	Convey("Given a valid request", t, func() {
 		currentTime := time.Now()
-		mockSession := &apiMock.SessionMock{
-			NewFunc: func(email string) (*session.Session, error) {
+		mockSession := &apiMock.UpdaterMock{
+			UpdateFunc: func(email string) (*session.Session, error) {
 				return &session.Session{
 					ID:    "1234",
 					Email: email,
@@ -173,7 +173,7 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
-				So(mockSession.NewCalls(), ShouldHaveLength, 1)
+				So(mockSession.UpdateCalls(), ShouldHaveLength, 1)
 				So(mockCache.SetCalls(), ShouldHaveLength, 1)
 			})
 		})

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -18,9 +18,9 @@ import (
 
 func TestCreateSessionHandlerFunc(t *testing.T) {
 	Convey("Given a valid request", t, func() {
-		mockSessions := &apiMock.SessionsMock{}
+		mockSession := &apiMock.SessionMock{}
 		mockCache := &apiMock.CacheMock{}
-		sessionHandler := api.CreateSessionHandlerFunc(mockSessions, mockCache)
+		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
 		req := httptest.NewRequest("POST", "http://localhost:24400/session", nil)
 		resp := httptest.NewRecorder()
@@ -30,14 +30,14 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusBadRequest)
-				So(mockSessions.NewCalls(), ShouldHaveLength, 0)
+				So(mockSession.NewCalls(), ShouldHaveLength, 0)
 			})
 		})
 	})
 
 	Convey("Given a valid request", t, func() {
 		currentTime := time.Now()
-		mockSessions := &apiMock.SessionsMock{
+		mockSession := &apiMock.SessionMock{
 			NewFunc: func(email string) (*session.Session, error) {
 				return &session.Session{
 					ID:    "1234",
@@ -51,7 +51,7 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 				return nil
 			},
 		}
-		sessionHandler := api.CreateSessionHandlerFunc(mockSessions, mockCache)
+		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
 		sessJSON, err := newSessionDetailsAndMarshal("test@test.com")
 		So(err, ShouldBeNil)
@@ -73,17 +73,17 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(resp.Body.String(), ShouldEqual, string(b))
 				So(resp.Code, ShouldEqual, 201)
-				So(mockSessions.NewCalls(), ShouldHaveLength, 1)
-				So(mockSessions.NewCalls()[0].Email, ShouldEqual, "test@test.com")
+				So(mockSession.NewCalls(), ShouldHaveLength, 1)
+				So(mockSession.NewCalls()[0].Email, ShouldEqual, "test@test.com")
 				So(mockCache.SetCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})
 
 	Convey("Given a bad request", t, func() {
-		mockSessions := &apiMock.SessionsMock{}
+		mockSession := &apiMock.SessionMock{}
 		mockCache := &apiMock.CacheMock{}
-		sessionHandler := api.CreateSessionHandlerFunc(mockSessions, mockCache)
+		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
 		req := httptest.NewRequest("POST", "/session", strings.NewReader("this is not json"))
 		resp := httptest.NewRecorder()
@@ -93,15 +93,15 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusBadRequest)
-				So(mockSessions.NewCalls(), ShouldHaveLength, 0)
+				So(mockSession.NewCalls(), ShouldHaveLength, 0)
 			})
 		})
 	})
 
 	Convey("Given a bad request", t, func() {
-		mockSessions := &apiMock.SessionsMock{}
+		mockSession := &apiMock.SessionMock{}
 		mockCache := &apiMock.CacheMock{}
-		sessionHandler := api.CreateSessionHandlerFunc(mockSessions, mockCache)
+		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
 		sessJSON, err := newSessionDetailsAndMarshal("")
 		So(err, ShouldBeNil)
@@ -114,19 +114,19 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusBadRequest)
-				So(mockSessions.NewCalls(), ShouldHaveLength, 0)
+				So(mockSession.NewCalls(), ShouldHaveLength, 0)
 			})
 		})
 	})
 
 	Convey("Given a new session", t, func() {
-		mockSessions := &apiMock.SessionsMock{
+		mockSession := &apiMock.SessionMock{
 			NewFunc: func(email string) (*session.Session, error) {
 				return nil, errors.New("unable to generate id")
 			},
 		}
 		mockCache := &apiMock.CacheMock{}
-		sessionHandler := api.CreateSessionHandlerFunc(mockSessions, mockCache)
+		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
 		sessJSON, err := newSessionDetailsAndMarshal("test@test.com")
 		So(err, ShouldBeNil)
@@ -139,14 +139,14 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
-				So(mockSessions.NewCalls(), ShouldHaveLength, 1)
+				So(mockSession.NewCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})
 
 	Convey("Given a valid request", t, func() {
 		currentTime := time.Now()
-		mockSessions := &apiMock.SessionsMock{
+		mockSession := &apiMock.SessionMock{
 			NewFunc: func(email string) (*session.Session, error) {
 				return &session.Session{
 					ID:    "1234",
@@ -160,7 +160,7 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 				return errors.New("unable to add session to cache")
 			},
 		}
-		sessionHandler := api.CreateSessionHandlerFunc(mockSessions, mockCache)
+		sessionHandler := api.CreateSessionHandlerFunc(mockSession, mockCache)
 
 		sessJSON, err := newSessionDetailsAndMarshal("test@test.com")
 		So(err, ShouldBeNil)
@@ -173,7 +173,7 @@ func TestCreateSessionHandlerFunc(t *testing.T) {
 
 			Convey("Then return an error response", func() {
 				So(resp.Code, ShouldEqual, http.StatusInternalServerError)
-				So(mockSessions.NewCalls(), ShouldHaveLength, 1)
+				So(mockSession.NewCalls(), ShouldHaveLength, 1)
 				So(mockCache.SetCalls(), ShouldHaveLength, 1)
 			})
 		})

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -1,7 +1,7 @@
 package api
 
 //go:generate moq -out mock/mockauth.go -pkg mock . AuthHandler
-//go:generate moq -out mock/mocksession.go -pkg mock . Updater
+//go:generate moq -out mock/mocksession.go -pkg mock . SessionUpdater
 //go:generate moq -out mock/mockcache.go -pkg mock . Cache
 
 import (
@@ -15,8 +15,8 @@ type AuthHandler interface {
 	Require(required auth.Permissions, handler http.HandlerFunc) http.HandlerFunc
 }
 
-// Updater interface for updating a session
-type Updater interface {
+// SessionUpdater interface for updating a session
+type SessionUpdater interface {
 	Update(email string) (*session.Session, error)
 }
 

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -1,7 +1,7 @@
 package api
 
 //go:generate moq -out mock/mockauth.go -pkg mock . AuthHandler
-//go:generate moq -out mock/mocksessions.go -pkg mock . Sessions
+//go:generate moq -out mock/mocksession.go -pkg mock . Session
 //go:generate moq -out mock/mockcache.go -pkg mock . Cache
 
 import (
@@ -15,8 +15,8 @@ type AuthHandler interface {
 	Require(required auth.Permissions, handler http.HandlerFunc) http.HandlerFunc
 }
 
-// Sessions interface for getting a new session
-type Sessions interface {
+// Session interface for getting a new session
+type Session interface {
 	New(email string) (*session.Session, error)
 }
 

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -1,7 +1,7 @@
 package api
 
 //go:generate moq -out mock/mockauth.go -pkg mock . AuthHandler
-//go:generate moq -out mock/mocksession.go -pkg mock . Session
+//go:generate moq -out mock/mocksession.go -pkg mock . Updater
 //go:generate moq -out mock/mockcache.go -pkg mock . Cache
 
 import (
@@ -15,9 +15,9 @@ type AuthHandler interface {
 	Require(required auth.Permissions, handler http.HandlerFunc) http.HandlerFunc
 }
 
-// Session interface for getting a new session
-type Session interface {
-	New(email string) (*session.Session, error)
+// Updater interface for updating a session
+type Updater interface {
+	Update(email string) (*session.Session, error)
 }
 
 // Cache interface for storing and retrieving sessions

--- a/api/mock/mocksession.go
+++ b/api/mock/mocksession.go
@@ -10,29 +10,29 @@ import (
 )
 
 var (
-	lockSessionsMockNew sync.RWMutex
+	lockSessionMockNew sync.RWMutex
 )
 
-// Ensure, that SessionsMock does implement Sessions.
+// Ensure, that SessionMock does implement Session.
 // If this is not the case, regenerate this file with moq.
-var _ api.Sessions = &SessionsMock{}
+var _ api.Session = &SessionMock{}
 
-// SessionsMock is a mock implementation of api.Sessions.
+// SessionMock is a mock implementation of api.Session.
 //
-//     func TestSomethingThatUsesSessions(t *testing.T) {
+//     func TestSomethingThatUsesSession(t *testing.T) {
 //
-//         // make and configure a mocked api.Sessions
-//         mockedSessions := &SessionsMock{
+//         // make and configure a mocked api.Session
+//         mockedSession := &SessionMock{
 //             NewFunc: func(email string) (*session.Session, error) {
 // 	               panic("mock out the New method")
 //             },
 //         }
 //
-//         // use mockedSessions in code that requires api.Sessions
+//         // use mockedSession in code that requires api.Session
 //         // and then make assertions.
 //
 //     }
-type SessionsMock struct {
+type SessionMock struct {
 	// NewFunc mocks the New method.
 	NewFunc func(email string) (*session.Session, error)
 
@@ -47,32 +47,32 @@ type SessionsMock struct {
 }
 
 // New calls NewFunc.
-func (mock *SessionsMock) New(email string) (*session.Session, error) {
+func (mock *SessionMock) New(email string) (*session.Session, error) {
 	if mock.NewFunc == nil {
-		panic("SessionsMock.NewFunc: method is nil but Sessions.New was just called")
+		panic("SessionMock.NewFunc: method is nil but Session.New was just called")
 	}
 	callInfo := struct {
 		Email string
 	}{
 		Email: email,
 	}
-	lockSessionsMockNew.Lock()
+	lockSessionMockNew.Lock()
 	mock.calls.New = append(mock.calls.New, callInfo)
-	lockSessionsMockNew.Unlock()
+	lockSessionMockNew.Unlock()
 	return mock.NewFunc(email)
 }
 
 // NewCalls gets all the calls that were made to New.
 // Check the length with:
-//     len(mockedSessions.NewCalls())
-func (mock *SessionsMock) NewCalls() []struct {
+//     len(mockedSession.NewCalls())
+func (mock *SessionMock) NewCalls() []struct {
 	Email string
 } {
 	var calls []struct {
 		Email string
 	}
-	lockSessionsMockNew.RLock()
+	lockSessionMockNew.RLock()
 	calls = mock.calls.New
-	lockSessionsMockNew.RUnlock()
+	lockSessionMockNew.RUnlock()
 	return calls
 }

--- a/api/mock/mocksession.go
+++ b/api/mock/mocksession.go
@@ -10,69 +10,69 @@ import (
 )
 
 var (
-	lockSessionMockNew sync.RWMutex
+	lockUpdaterMockUpdate sync.RWMutex
 )
 
-// Ensure, that SessionMock does implement Session.
+// Ensure, that UpdaterMock does implement Updater.
 // If this is not the case, regenerate this file with moq.
-var _ api.Session = &SessionMock{}
+var _ api.Updater = &UpdaterMock{}
 
-// SessionMock is a mock implementation of api.Session.
+// UpdaterMock is a mock implementation of api.Updater.
 //
-//     func TestSomethingThatUsesSession(t *testing.T) {
+//     func TestSomethingThatUsesUpdater(t *testing.T) {
 //
-//         // make and configure a mocked api.Session
-//         mockedSession := &SessionMock{
-//             NewFunc: func(email string) (*session.Session, error) {
-// 	               panic("mock out the New method")
+//         // make and configure a mocked api.Updater
+//         mockedUpdater := &UpdaterMock{
+//             UpdateFunc: func(email string) (*session.Session, error) {
+// 	               panic("mock out the Update method")
 //             },
 //         }
 //
-//         // use mockedSession in code that requires api.Session
+//         // use mockedUpdater in code that requires api.Updater
 //         // and then make assertions.
 //
 //     }
-type SessionMock struct {
-	// NewFunc mocks the New method.
-	NewFunc func(email string) (*session.Session, error)
+type UpdaterMock struct {
+	// UpdateFunc mocks the Update method.
+	UpdateFunc func(email string) (*session.Session, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// New holds details about calls to the New method.
-		New []struct {
+		// Update holds details about calls to the Update method.
+		Update []struct {
 			// Email is the email argument value.
 			Email string
 		}
 	}
 }
 
-// New calls NewFunc.
-func (mock *SessionMock) New(email string) (*session.Session, error) {
-	if mock.NewFunc == nil {
-		panic("SessionMock.NewFunc: method is nil but Session.New was just called")
+// Update calls UpdateFunc.
+func (mock *UpdaterMock) Update(email string) (*session.Session, error) {
+	if mock.UpdateFunc == nil {
+		panic("UpdaterMock.UpdateFunc: method is nil but Updater.Update was just called")
 	}
 	callInfo := struct {
 		Email string
 	}{
 		Email: email,
 	}
-	lockSessionMockNew.Lock()
-	mock.calls.New = append(mock.calls.New, callInfo)
-	lockSessionMockNew.Unlock()
-	return mock.NewFunc(email)
+	lockUpdaterMockUpdate.Lock()
+	mock.calls.Update = append(mock.calls.Update, callInfo)
+	lockUpdaterMockUpdate.Unlock()
+	return mock.UpdateFunc(email)
 }
 
-// NewCalls gets all the calls that were made to New.
+// UpdateCalls gets all the calls that were made to Update.
 // Check the length with:
-//     len(mockedSession.NewCalls())
-func (mock *SessionMock) NewCalls() []struct {
+//     len(mockedUpdater.UpdateCalls())
+func (mock *UpdaterMock) UpdateCalls() []struct {
 	Email string
 } {
 	var calls []struct {
 		Email string
 	}
-	lockSessionMockNew.RLock()
-	calls = mock.calls.New
-	lockSessionMockNew.RUnlock()
+	lockUpdaterMockUpdate.RLock()
+	calls = mock.calls.Update
+	lockUpdaterMockUpdate.RUnlock()
 	return calls
 }

--- a/api/mock/mocksession.go
+++ b/api/mock/mocksession.go
@@ -10,29 +10,29 @@ import (
 )
 
 var (
-	lockUpdaterMockUpdate sync.RWMutex
+	lockSessionUpdaterMockUpdate sync.RWMutex
 )
 
-// Ensure, that UpdaterMock does implement Updater.
+// Ensure, that SessionUpdaterMock does implement SessionUpdater.
 // If this is not the case, regenerate this file with moq.
-var _ api.Updater = &UpdaterMock{}
+var _ api.SessionUpdater = &SessionUpdaterMock{}
 
-// UpdaterMock is a mock implementation of api.Updater.
+// SessionUpdaterMock is a mock implementation of api.SessionUpdater.
 //
-//     func TestSomethingThatUsesUpdater(t *testing.T) {
+//     func TestSomethingThatUsesSessionUpdater(t *testing.T) {
 //
-//         // make and configure a mocked api.Updater
-//         mockedUpdater := &UpdaterMock{
+//         // make and configure a mocked api.SessionUpdater
+//         mockedSessionUpdater := &SessionUpdaterMock{
 //             UpdateFunc: func(email string) (*session.Session, error) {
 // 	               panic("mock out the Update method")
 //             },
 //         }
 //
-//         // use mockedUpdater in code that requires api.Updater
+//         // use mockedSessionUpdater in code that requires api.SessionUpdater
 //         // and then make assertions.
 //
 //     }
-type UpdaterMock struct {
+type SessionUpdaterMock struct {
 	// UpdateFunc mocks the Update method.
 	UpdateFunc func(email string) (*session.Session, error)
 
@@ -47,32 +47,32 @@ type UpdaterMock struct {
 }
 
 // Update calls UpdateFunc.
-func (mock *UpdaterMock) Update(email string) (*session.Session, error) {
+func (mock *SessionUpdaterMock) Update(email string) (*session.Session, error) {
 	if mock.UpdateFunc == nil {
-		panic("UpdaterMock.UpdateFunc: method is nil but Updater.Update was just called")
+		panic("SessionUpdaterMock.UpdateFunc: method is nil but SessionUpdater.Update was just called")
 	}
 	callInfo := struct {
 		Email string
 	}{
 		Email: email,
 	}
-	lockUpdaterMockUpdate.Lock()
+	lockSessionUpdaterMockUpdate.Lock()
 	mock.calls.Update = append(mock.calls.Update, callInfo)
-	lockUpdaterMockUpdate.Unlock()
+	lockSessionUpdaterMockUpdate.Unlock()
 	return mock.UpdateFunc(email)
 }
 
 // UpdateCalls gets all the calls that were made to Update.
 // Check the length with:
-//     len(mockedUpdater.UpdateCalls())
-func (mock *UpdaterMock) UpdateCalls() []struct {
+//     len(mockedSessionUpdater.UpdateCalls())
+func (mock *SessionUpdaterMock) UpdateCalls() []struct {
 	Email string
 } {
 	var calls []struct {
 		Email string
 	}
-	lockUpdaterMockUpdate.RLock()
+	lockSessionUpdaterMockUpdate.RLock()
 	calls = mock.calls.Update
-	lockUpdaterMockUpdate.RUnlock()
+	lockSessionUpdaterMockUpdate.RUnlock()
 	return calls
 }

--- a/api/nop.go
+++ b/api/nop.go
@@ -17,7 +17,7 @@ type NOPSession struct{}
 type NOPCache struct{}
 
 // New creates a new session using an email address
-func (n *NOPSession) New(email string) (*session.Session, error) {
+func (n *NOPSession) Update(email string) (*session.Session, error) {
 	startP := parseTime()
 	var sess = &session.Session{
 		ID:    NOPSessionID,

--- a/api/nop.go
+++ b/api/nop.go
@@ -11,13 +11,13 @@ const (
 )
 
 // NOPSessions no-op struct
-type NOPSessions struct{}
+type NOPSession struct{}
 
 // NOPCache no-op struct
 type NOPCache struct{}
 
 // New creates a new session using an email address
-func (n *NOPSessions) New(email string) (*session.Session, error) {
+func (n *NOPSession) New(email string) (*session.Session, error) {
 	startP := parseTime()
 	var sess = &session.Session{
 		ID:    NOPSessionID,

--- a/session/session.go
+++ b/session/session.go
@@ -45,8 +45,8 @@ func NewSession() *Session {
 	}
 }
 
-// New creates a new session using email parameter
-func (sess *Session) New(email string) (*Session, error) {
+// UpdateSession updates the session with email parameter
+func (s *Session) Update(email string) (*Session, error) {
 	id, err := newID()
 	if err != nil {
 		return nil, err
@@ -61,12 +61,12 @@ func (sess *Session) New(email string) (*Session, error) {
 }
 
 // MarshalJSON used to marshal Session object for outgoing requests
-func (sess *Session) MarshalJSON() ([]byte, error) {
+func (s *Session) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&jsonModel{
-		ID:           sess.ID,
-		Email:        sess.Email,
-		Start:        sess.Start.Format(dateTimeFMT),
-		LastAccessed: sess.LastAccessed.Format(dateTimeFMT),
+		ID:           s.ID,
+		Email:        s.Email,
+		Start:        s.Start.Format(dateTimeFMT),
+		LastAccessed: s.LastAccessed.Format(dateTimeFMT),
 	})
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -35,6 +35,31 @@ type jsonModel struct {
 	LastAccessed string `json:"last_accessed"`
 }
 
+// NewSession creates a new session
+func NewSession() *Session {
+	return &Session{
+		ID:           "",
+		Email:        "",
+		Start:        time.Time{},
+		LastAccessed: time.Time{},
+	}
+}
+
+// New creates a new session using email parameter
+func (sess *Session) New(email string) (*Session, error) {
+	id, err := newID()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Session{
+		ID:           id,
+		Email:        email,
+		Start:        time.Now(),
+		LastAccessed: time.Now(),
+	}, nil
+}
+
 // MarshalJSON used to marshal Session object for outgoing requests
 func (sess *Session) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&jsonModel{
@@ -43,21 +68,6 @@ func (sess *Session) MarshalJSON() ([]byte, error) {
 		Start:        sess.Start.Format(dateTimeFMT),
 		LastAccessed: sess.LastAccessed.Format(dateTimeFMT),
 	})
-}
-
-// CreateNewSession creates a new session using email parameter
-func CreateNewSession(email string) (Session, error) {
-	id, err := newID()
-	if err != nil {
-		return Session{}, err
-	}
-
-	return Session{
-		ID:           id,
-		Email:        email,
-		Start:        time.Now(),
-		LastAccessed: time.Now(),
-	}, nil
 }
 
 func newID() (string, error) {


### PR DESCRIPTION
Removed pluralisation of sessions where it wasn't supposed to happen
Updated the sessions interface, and sessions.go to match interface and noop implementations.

Just sanity check on changes. 