### PR TITLE
Made TLS configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,17 @@ API for Sessions
 
 | Environment variable         | Default   | Description
 | ---------------------------- | --------- | -----------
-| BIND_ADDR                    | :    | The host and port to bind to
+| BIND_ADDR                    | :         | The host and port to bind to
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s        | The graceful shutdown timeout in seconds (`time.Duration` format)
 | HEALTHCHECK_INTERVAL         | 10s       | Time between self-healthchecks (`time.Duration` format)
 | HEALTHCHECK_CRITICAL_TIMEOUT | 1m        | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| ZEBEDEE_URL                  | http://localhost:8082 | URL for Zebedee
+| SERVICE_AUTH_TOKEN           |           | Service Auth token for communicating with Zebedee
+| ELASTICACHE_ADDR             | localhost:6379 | Address of Elasticache/Redis
+| ELASTICACHE_PASSWORD         | default   | Password for Elasticache/Redis
+| ELASTICACHE_DATABASE         | 0         | Database for Elasticache/Redis (`int` format)
+| ELASTICACHE_TTL              | 30m       | Time before Elasticache/Redis key expires (`time.Duration` format)
+| ENABLE_REDIS_TLS_CONFIG      | false     | Turn TLS configuration on or off (`bool` format)
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	ElasticachePassword        string        `envconfig:"ELASTICACHE_PASSWORD"				json:"-"`
 	ElasticacheDatabase        int           `envconfig:"ELASTICACHE_DATABASE"`
 	ElasticacheTTL             time.Duration `envconfig:"ELASTICACHE_TTL"`
+	EnableTLSConfig            bool          `envconfig:"ENABLE_TLS_CONFIG"`
 }
 
 var cfg *Config
@@ -39,6 +40,7 @@ func Get() (*Config, error) {
 		ElasticachePassword:        "default",
 		ElasticacheDatabase:        0,
 		ElasticacheTTL:             30 * time.Minute,
+		EnableTLSConfig:            false,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	ElasticachePassword        string        `envconfig:"ELASTICACHE_PASSWORD"				json:"-"`
 	ElasticacheDatabase        int           `envconfig:"ELASTICACHE_DATABASE"`
 	ElasticacheTTL             time.Duration `envconfig:"ELASTICACHE_TTL"`
-	EnableTLSConfig            bool          `envconfig:"ENABLE_TLS_CONFIG"`
+	EnableRedisTLSConfig       bool          `envconfig:"ENABLE_REDIS_TLS_CONFIG"`
 }
 
 var cfg *Config
@@ -40,7 +40,7 @@ func Get() (*Config, error) {
 		ElasticachePassword:        "default",
 		ElasticacheDatabase:        0,
 		ElasticacheTTL:             30 * time.Minute,
-		EnableTLSConfig:            false,
+		EnableRedisTLSConfig:       false,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-authorisation v0.1.0
 	github.com/ONSdigital/dp-healthcheck v1.0.4
 	github.com/ONSdigital/dp-net v1.0.3
-	github.com/ONSdigital/dp-redis v0.1.1-0.20201105150102-768df9d1e4b9
+	github.com/ONSdigital/dp-redis v0.1.1-0.20201105154625-374eb8ee843a
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/google/uuid v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-authorisation v0.1.0
 	github.com/ONSdigital/dp-healthcheck v1.0.4
 	github.com/ONSdigital/dp-net v1.0.3
-	github.com/ONSdigital/dp-redis v0.1.1-0.20201105154625-374eb8ee843a
+	github.com/ONSdigital/dp-redis v1.0.0
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/google/uuid v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-authorisation v0.1.0
 	github.com/ONSdigital/dp-healthcheck v1.0.4
 	github.com/ONSdigital/dp-net v1.0.3
-	github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810
+	github.com/ONSdigital/dp-redis v0.1.1-0.20201105150102-768df9d1e4b9
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810 h1:TDqOBn9y2
 github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-redis v0.1.1-0.20201105150102-768df9d1e4b9 h1:HJzhAGPqykwFoXPmEeL9YjAiUeplVDTv/inK6LSEVpE=
 github.com/ONSdigital/dp-redis v0.1.1-0.20201105150102-768df9d1e4b9/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
+github.com/ONSdigital/dp-redis v0.1.1-0.20201105154625-374eb8ee843a h1:OMqSFj9OEBhQ3t9HRsk62TEAFJ8i3ducWwAIHEBwv6I=
+github.com/ONSdigital/dp-redis v0.1.1-0.20201105154625-374eb8ee843a/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-sessions-api v0.2.0/go.mod h1:AGACIcN8ZHWuPU3XsES8w311YIb+pVCduTJiR6BUgzQ=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad h1:Axoxm5rF6j7LSZfm4AGBT5IwGhWIcfcOkkhy/su/UpA=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/ONSdigital/dp-redis v0.1.1-0.20201105150102-768df9d1e4b9 h1:HJzhAGPqy
 github.com/ONSdigital/dp-redis v0.1.1-0.20201105150102-768df9d1e4b9/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-redis v0.1.1-0.20201105154625-374eb8ee843a h1:OMqSFj9OEBhQ3t9HRsk62TEAFJ8i3ducWwAIHEBwv6I=
 github.com/ONSdigital/dp-redis v0.1.1-0.20201105154625-374eb8ee843a/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
+github.com/ONSdigital/dp-redis v1.0.0 h1:UqNJlzywe6ia1JpeaTIbRAsqHuaPU79af8YnMT+hSYw=
+github.com/ONSdigital/dp-redis v1.0.0/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-sessions-api v0.2.0/go.mod h1:AGACIcN8ZHWuPU3XsES8w311YIb+pVCduTJiR6BUgzQ=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad h1:Axoxm5rF6j7LSZfm4AGBT5IwGhWIcfcOkkhy/su/UpA=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/ONSdigital/dp-redis v0.1.1-0.20201021151824-9adb7ba2e879 h1:Q/ADIvy4H
 github.com/ONSdigital/dp-redis v0.1.1-0.20201021151824-9adb7ba2e879/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810 h1:TDqOBn9y2g7LFhnAwqQjY1a31j2sbFW7eBGGZHrqlxE=
 github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
+github.com/ONSdigital/dp-redis v0.1.1-0.20201105150102-768df9d1e4b9 h1:HJzhAGPqykwFoXPmEeL9YjAiUeplVDTv/inK6LSEVpE=
+github.com/ONSdigital/dp-redis v0.1.1-0.20201105150102-768df9d1e4b9/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-sessions-api v0.2.0/go.mod h1:AGACIcN8ZHWuPU3XsES8w311YIb+pVCduTJiR6BUgzQ=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad h1:Axoxm5rF6j7LSZfm4AGBT5IwGhWIcfcOkkhy/su/UpA=

--- a/service/service.go
+++ b/service/service.go
@@ -55,7 +55,7 @@ func Run(buildTime, gitCommit, version string, svcErrors chan error) (*Service, 
 	zebedeeClient := zebedee.New(cfg.ZebedeeURL)
 
 	var elasticacheClient *dpredis.Client
-	if cfg.EnableTLSConfig {
+	if cfg.EnableRedisTLSConfig {
 		elasticacheClient, err = dpredis.NewClient(dpredis.Config{
 			Addr:     cfg.ElasticacheAddr,
 			Password: cfg.ElasticachePassword,


### PR DESCRIPTION
Making TLS configurable to allow developers to run against local instance of redis.

Run redis locally in docker and run application. 
Check http://localhost:24400/health to see redis connecting.
`$ make debug`
`$ docker run -p 6379:6379 --name redis -d redis:6.0 redis-server --requirepass "default"`
