### PR TITLE
Adding GetByEmail() functionality

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -25,6 +25,7 @@ func Setup(ctx context.Context, r *mux.Router, permissions AuthHandler, elastica
 
 	r.HandleFunc("/sessions", permissions.Require(create, CreateSessionHandlerFunc(elasticacheClient))).Methods("POST")
 	r.HandleFunc("/sessions/{ID}", GetByIDSessionHandlerFunc(elasticacheClient, mux.Vars)).Methods("GET")
+	r.HandleFunc("/sessions/{Email}", GetByEmailSessionHandlerFunc(elasticacheClient, mux.Vars)).Methods("GET")
 	r.HandleFunc("/sessions", permissions.Require(delete, DeleteAllSessionsHandlerFunc(elasticacheClient))).Methods("DELETE")
 	return api
 }

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -24,5 +24,6 @@ type SessionUpdater interface {
 type Cache interface {
 	SetSession(s *session.Session) error
 	GetByID(ID string) (*session.Session, error)
+	GetByEmail(email string) (*session.Session, error)
 	DeleteAll() error
 }

--- a/api/mock/mockcache.go
+++ b/api/mock/mockcache.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	lockCacheMockDeleteAll  sync.RWMutex
+	lockCacheMockGetByEmail sync.RWMutex
 	lockCacheMockGetByID    sync.RWMutex
 	lockCacheMockSetSession sync.RWMutex
 )
@@ -28,6 +29,9 @@ var _ api.Cache = &CacheMock{}
 //             DeleteAllFunc: func() error {
 // 	               panic("mock out the DeleteAll method")
 //             },
+//             GetByEmailFunc: func(email string) (*session.Session, error) {
+// 	               panic("mock out the GetByEmail method")
+//             },
 //             GetByIDFunc: func(ID string) (*session.Session, error) {
 // 	               panic("mock out the GetByID method")
 //             },
@@ -44,6 +48,9 @@ type CacheMock struct {
 	// DeleteAllFunc mocks the DeleteAll method.
 	DeleteAllFunc func() error
 
+	// GetByEmailFunc mocks the GetByEmail method.
+	GetByEmailFunc func(email string) (*session.Session, error)
+
 	// GetByIDFunc mocks the GetByID method.
 	GetByIDFunc func(ID string) (*session.Session, error)
 
@@ -54,6 +61,11 @@ type CacheMock struct {
 	calls struct {
 		// DeleteAll holds details about calls to the DeleteAll method.
 		DeleteAll []struct {
+		}
+		// GetByEmail holds details about calls to the GetByEmail method.
+		GetByEmail []struct {
+			// Email is the email argument value.
+			Email string
 		}
 		// GetByID holds details about calls to the GetByID method.
 		GetByID []struct {
@@ -91,6 +103,37 @@ func (mock *CacheMock) DeleteAllCalls() []struct {
 	lockCacheMockDeleteAll.RLock()
 	calls = mock.calls.DeleteAll
 	lockCacheMockDeleteAll.RUnlock()
+	return calls
+}
+
+// GetByEmail calls GetByEmailFunc.
+func (mock *CacheMock) GetByEmail(email string) (*session.Session, error) {
+	if mock.GetByEmailFunc == nil {
+		panic("CacheMock.GetByEmailFunc: method is nil but Cache.GetByEmail was just called")
+	}
+	callInfo := struct {
+		Email string
+	}{
+		Email: email,
+	}
+	lockCacheMockGetByEmail.Lock()
+	mock.calls.GetByEmail = append(mock.calls.GetByEmail, callInfo)
+	lockCacheMockGetByEmail.Unlock()
+	return mock.GetByEmailFunc(email)
+}
+
+// GetByEmailCalls gets all the calls that were made to GetByEmail.
+// Check the length with:
+//     len(mockedCache.GetByEmailCalls())
+func (mock *CacheMock) GetByEmailCalls() []struct {
+	Email string
+} {
+	var calls []struct {
+		Email string
+	}
+	lockCacheMockGetByEmail.RLock()
+	calls = mock.calls.GetByEmail
+	lockCacheMockGetByEmail.RUnlock()
 	return calls
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-authorisation v0.1.0
 	github.com/ONSdigital/dp-healthcheck v1.0.4
 	github.com/ONSdigital/dp-net v1.0.3
-	github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810
+	github.com/ONSdigital/dp-redis v0.1.1-0.20201105154625-374eb8ee843a
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,10 @@ github.com/ONSdigital/dp-redis v0.1.1-0.20201021151824-9adb7ba2e879 h1:Q/ADIvy4H
 github.com/ONSdigital/dp-redis v0.1.1-0.20201021151824-9adb7ba2e879/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810 h1:TDqOBn9y2g7LFhnAwqQjY1a31j2sbFW7eBGGZHrqlxE=
 github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
+github.com/ONSdigital/dp-redis v0.1.1-0.20201105142245-90a5a44eb125 h1:7KmdWO8hBrnqA5Tbwwq4uako7jVPkI6Y8LfZf1xr8LQ=
+github.com/ONSdigital/dp-redis v0.1.1-0.20201105142245-90a5a44eb125/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
+github.com/ONSdigital/dp-redis v0.1.1-0.20201105154625-374eb8ee843a h1:OMqSFj9OEBhQ3t9HRsk62TEAFJ8i3ducWwAIHEBwv6I=
+github.com/ONSdigital/dp-redis v0.1.1-0.20201105154625-374eb8ee843a/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-sessions-api v0.2.0/go.mod h1:AGACIcN8ZHWuPU3XsES8w311YIb+pVCduTJiR6BUgzQ=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad h1:Axoxm5rF6j7LSZfm4AGBT5IwGhWIcfcOkkhy/su/UpA=

--- a/go.sum
+++ b/go.sum
@@ -32,12 +32,6 @@ github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8 h1:MWIHCr/ud5
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
 github.com/ONSdigital/dp-rchttp v1.0.0 h1:K/1/gDtfMZCX1Mbmq80nZxzDirzneqA1c89ea26FqP4=
 github.com/ONSdigital/dp-rchttp v1.0.0/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
-github.com/ONSdigital/dp-redis v0.1.0 h1:twdLQwCO6cdaLKwGKsh8WpCtXsn3AVqPOQGh5ybENBY=
-github.com/ONSdigital/dp-redis v0.1.0/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
-github.com/ONSdigital/dp-redis v0.1.1-0.20201021151824-9adb7ba2e879 h1:Q/ADIvy4H8jwt3tBRb2kjJ4V6STy7GNTEtBuz+XAHUI=
-github.com/ONSdigital/dp-redis v0.1.1-0.20201021151824-9adb7ba2e879/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
-github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810 h1:TDqOBn9y2g7LFhnAwqQjY1a31j2sbFW7eBGGZHrqlxE=
-github.com/ONSdigital/dp-redis v0.1.1-0.20201022125855-9be9f01a5810/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-redis v1.0.0 h1:UqNJlzywe6ia1JpeaTIbRAsqHuaPU79af8YnMT+hSYw=
 github.com/ONSdigital/dp-redis v1.0.0/go.mod h1:HVAzhdywQg6Yuu9Hd4Zg0YOOUDHUHM/je6Ne9f4FwCs=
 github.com/ONSdigital/dp-sessions-api v0.2.0/go.mod h1:AGACIcN8ZHWuPU3XsES8w311YIb+pVCduTJiR6BUgzQ=

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -15,7 +15,7 @@ paths:
   /sessions:
     post:
       security:
-        - ServiceToken: []
+        - ServiceToken: [ ]
       tags:
         - session
       summary: Create a session endpoint
@@ -43,7 +43,7 @@ paths:
           description: Internal Server Error
     delete:
       security:
-        - ServiceToken: []
+        - ServiceToken: [ ]
       tags:
         - session
       summary: Delete all sessions
@@ -82,6 +82,29 @@ paths:
           description: Not Found
         500:
           description: Internal Server Error
+  /sessions/{Email}:
+      get:
+        tags:
+          - session
+        summary: Get a session by ID endpoint
+        description: Gets an existing session by the provided ID.
+        parameters:
+          - in: path
+            name: ID
+            type: string
+            required: true
+            description: ID of stored session
+        produces:
+          - application/json
+        responses:
+          200:
+            description: OK
+            schema:
+              $ref: "#/definitions/Session"
+          404:
+            description: Not Found
+          500:
+            description: Internal Server Error
 
 securityDefinitions:
   ServiceToken:


### PR DESCRIPTION
Updated dp-sessions-api to now get sessions by email address.

- Check tests run and pass
- Make sure there aren't any obvious issues within the code

To test locally you will need redis running:
`$ docker run -p 6379:6379 --name redis -d redis:6.0 redis-server --requirepass "redis"`

Make sure to be running the Publishing stack for authentication to work for `POST` of new session.

Run dp-sessions-api:
`$ make debug`