### PR TITLE
updated client to return specific error for session not found

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -19,7 +19,7 @@ const (
 type GetVarsFunc func(r *http.Request) map[string]string
 
 // CreateSessionHandlerFunc returns a function that generates a session. Method = "POST"
-func CreateSessionHandlerFunc(cache Cache) http.HandlerFunc {
+func CreateSessionHandlerFunc(sessionCache Cache) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -41,7 +41,7 @@ func CreateSessionHandlerFunc(cache Cache) http.HandlerFunc {
 			return
 		}
 
-		if err := cache.SetSession(s); err != nil {
+		if err := sessionCache.SetSession(s); err != nil {
 			writeErrorResponse(ctx, w, "unable to add session to cache", err, http.StatusInternalServerError)
 			return
 		}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -3,54 +3,59 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/ONSdigital/dp-sessions-api/cache"
 	"github.com/ONSdigital/dp-sessions-api/session"
 	"github.com/ONSdigital/log.go/log"
+	"github.com/pkg/errors"
 )
 
 const (
-	internalServerErr  = "internal server error"
-	sessionNotFoundErr = "session not found"
+	internalServerErr    = "internal server error"
+	sessionNotFoundErr   = "session not found"
+	marshallSessionErr   = "failed to marshal session to JSON"
+	unmarshallSessionErr = "failed to unmarshal session JSON"
+	sessionEmailEmptyErr = "session.Email required but was empty"
+	createSessionErr     = "error creating new session"
+	addSessionToCacheErr = "error adding new session to cache"
+)
+
+var (
+	sessionNilErr = errors.New("expected session object but was nil")
 )
 
 // GetVarsFunc is a helper function that returns a map of request variables and parameters
 type GetVarsFunc func(r *http.Request) map[string]string
 
-// CreateSessionHandlerFunc returns a function that generates a session. Method = "POST"
+// CreateSessionHandlerFunc returns HTTP HandlerFunc for handling POST requests to create sessions.
 func CreateSessionHandlerFunc(sessionCache Cache) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		var c session.NewSessionDetails
-		err := json.NewDecoder(r.Body).Decode(&c)
-		if err != nil {
-			writeErrorResponse(ctx, w, "failed to unmarshal request body", err, http.StatusBadRequest)
+		email, getEmailErr := getEmailForNewSession(r.Body)
+		if getEmailErr != nil {
+			writeErrorResponse(ctx, w, sessionEmailEmptyErr, getEmailErr, http.StatusBadRequest)
 			return
 		}
 
-		if len(c.Email) == 0 {
-			writeErrorResponse(ctx, w, "missing email field in json", err, http.StatusBadRequest)
+		s, newSessErr := session.New(email)
+		if newSessErr != nil {
+			writeErrorResponse(ctx, w, createSessionErr, newSessErr, http.StatusInternalServerError)
 			return
 		}
 
-		s, err := session.NewSession().Update(c.Email)
-		if err != nil {
-			writeErrorResponse(ctx, w, "failed to create session", err, http.StatusInternalServerError)
+		if cacheSessErr := sessionCache.SetSession(s); cacheSessErr != nil {
+			writeErrorResponse(ctx, w, addSessionToCacheErr, cacheSessErr, http.StatusInternalServerError)
 			return
 		}
 
-		if err := sessionCache.SetSession(s); err != nil {
-			writeErrorResponse(ctx, w, "unable to add session to cache", err, http.StatusInternalServerError)
-			return
-		}
+		log.Event(ctx, "session was successfully added to cache", log.INFO, log.Data{"email": s.Email})
 
-		log.Event(ctx, "session added to cache", log.INFO)
-
-		sessionJSON, err := s.MarshalJSON()
-		if err != nil {
-			writeErrorResponse(ctx, w, "failed to marshal session", err, http.StatusInternalServerError)
+		sessionJSON, marshalErr := s.MarshalJSON()
+		if marshalErr != nil {
+			writeErrorResponse(ctx, w, marshallSessionErr, marshalErr, http.StatusInternalServerError)
 			return
 		}
 
@@ -60,31 +65,44 @@ func CreateSessionHandlerFunc(sessionCache Cache) http.HandlerFunc {
 	}
 }
 
-// GetByIDSessionHandlerFunc returns a function that retrieves a session by ID from the cache
+func getEmailForNewSession(r io.Reader) (string, error) {
+	var details session.NewSessionDetails
+	if err := json.NewDecoder(r).Decode(&details); err != nil {
+		return "", errors.WithMessage(err, unmarshallSessionErr)
+	}
+
+	if len(details.Email) == 0 {
+		return "", errors.New(sessionEmailEmptyErr)
+	}
+
+	return details.Email, nil
+}
+
+// GetByIDSessionHandlerFunc returns a HTTP HandlerFunc that attempts to retrieve an existing session by ID from the cache
 func GetByIDSessionHandlerFunc(sessionCache Cache, getVarsFunc GetVarsFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		ID := getVarsFunc(r)["ID"]
 
-		s, err := sessionCache.GetByID(ID)
-		if err != nil {
-			if err == cache.ErrSessionNotFound {
-				writeErrorResponse(ctx, w, sessionNotFoundErr, err, http.StatusNotFound)
+		s, getSessErr := sessionCache.GetByID(ID)
+		if getSessErr != nil {
+			if getSessErr == cache.ErrSessionNotFound {
+				writeErrorResponse(ctx, w, sessionNotFoundErr, getSessErr, http.StatusNotFound)
 				return
 			}
 
-			writeErrorResponse(ctx, w, internalServerErr, err, http.StatusInternalServerError)
+			writeErrorResponse(ctx, w, internalServerErr, getSessErr, http.StatusInternalServerError)
 			return
 		}
 
 		if s == nil {
-			writeErrorResponse(ctx, w, internalServerErr, err, http.StatusInternalServerError)
+			writeErrorResponse(ctx, w, internalServerErr, sessionNilErr, http.StatusInternalServerError)
 			return
 		}
 
-		sessionJSON, err := s.MarshalJSON()
-		if err != nil {
-			writeErrorResponse(ctx, w, internalServerErr, err, http.StatusInternalServerError)
+		sessionJSON, marshalErr := json.Marshal(s)
+		if marshalErr != nil {
+			writeErrorResponse(ctx, w, marshallSessionErr, marshalErr, http.StatusInternalServerError)
 			return
 		}
 
@@ -94,31 +112,31 @@ func GetByIDSessionHandlerFunc(sessionCache Cache, getVarsFunc GetVarsFunc) http
 	}
 }
 
-// GetByEmailSessionHandlerFunc returns a function that retrieves a session by ID from the cache
+// GetByEmailSessionHandlerFunc returns a HTTP HandlerFunc that attempts to retrieve an existing session by Email from the cache
 func GetByEmailSessionHandlerFunc(sessionCache Cache, getVarsFunc GetVarsFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		email := getVarsFunc(r)["Email"]
 
-		s, err := sessionCache.GetByEmail(email)
-		if err != nil {
-			if err == cache.ErrSessionNotFound {
-				writeErrorResponse(ctx, w, sessionNotFoundErr, err, http.StatusNotFound)
+		s, getSessErr := sessionCache.GetByEmail(email)
+		if getSessErr != nil {
+			if getSessErr == cache.ErrSessionNotFound {
+				writeErrorResponse(ctx, w, sessionNotFoundErr, getSessErr, http.StatusNotFound)
 				return
 			}
 
-			writeErrorResponse(ctx, w, internalServerErr, err, http.StatusInternalServerError)
+			writeErrorResponse(ctx, w, internalServerErr, getSessErr, http.StatusInternalServerError)
 			return
 		}
 
 		if s == nil {
-			writeErrorResponse(ctx, w, internalServerErr, err, http.StatusInternalServerError)
+			writeErrorResponse(ctx, w, internalServerErr, sessionNilErr, http.StatusInternalServerError)
 			return
 		}
 
-		sessionJSON, err := s.MarshalJSON()
-		if err != nil {
-			writeErrorResponse(ctx, w, internalServerErr, err, http.StatusInternalServerError)
+		sessionJSON, marshalErr := json.Marshal(s)
+		if marshalErr != nil {
+			writeErrorResponse(ctx, w, internalServerErr, marshalErr, http.StatusInternalServerError)
 			return
 		}
 
@@ -143,11 +161,6 @@ func DeleteAllSessionsHandlerFunc(cache Cache) http.HandlerFunc {
 }
 
 func writeErrorResponse(ctx context.Context, w http.ResponseWriter, msg string, err error, status int) {
-	if err != nil {
-		log.Event(ctx, err.Error(), log.Error(err), log.ERROR)
-	} else {
-		log.Event(ctx, msg, log.ERROR)
-	}
-
+	log.Event(ctx, err.Error(), log.ERROR, log.Error(err))
 	http.Error(w, msg, status)
 }

--- a/cache/elasticache_client.go
+++ b/cache/elasticache_client.go
@@ -21,6 +21,7 @@ var (
 	ErrEmptyAddress      = errors.New("address is empty")
 	ErrEmptyPassword     = errors.New("password is empty")
 	ErrInvalidTTL        = errors.New("ttl should not be zero")
+	ErrSessionNotFound   = errors.New("session not found")
 )
 
 type ElasticacheClient struct {
@@ -88,7 +89,8 @@ func (c *ElasticacheClient) SetSession(s *session.Session) error {
 	return nil
 }
 
-// GetByID - gets a session from elasticache using its ID
+// GetByID - gets a session from elasticache by the Session ID.
+// Returns cache.ErrSessionNotFound if the session is not found in the cache.
 func (c *ElasticacheClient) GetByID(id string) (*session.Session, error) {
 	if id == "" {
 		return nil, ErrEmptySessionID
@@ -96,6 +98,9 @@ func (c *ElasticacheClient) GetByID(id string) (*session.Session, error) {
 
 	msg, err := c.client.Get(id).Result()
 	if err != nil {
+		if err == redis.Nil {
+			return nil, ErrSessionNotFound
+		}
 		return nil, err
 	}
 
@@ -129,6 +134,9 @@ func (c *ElasticacheClient) GetByEmail(email string) (*session.Session, error) {
 
 	msg, err := c.client.Get(email).Result()
 	if err != nil {
+		if err == redis.Nil {
+			return nil, ErrSessionNotFound
+		}
 		return nil, err
 	}
 

--- a/cache/elasticache_client.go
+++ b/cache/elasticache_client.go
@@ -90,7 +90,7 @@ func (c *ElasticacheClient) SetSession(s *session.Session) error {
 }
 
 // GetByID - gets a session from elasticache by the Session ID.
-// Returns cache.ErrSessionNotFound if the session is not found in the cache.
+// Returns cache.ErrSessionNotFound if the session with the specified ID does not exist.
 func (c *ElasticacheClient) GetByID(id string) (*session.Session, error) {
 	if id == "" {
 		return nil, ErrEmptySessionID
@@ -126,7 +126,8 @@ func (c *ElasticacheClient) GetByID(id string) (*session.Session, error) {
 	return s, nil
 }
 
-// GetByEmail - gets a session from elasticache using its ID
+// GetByEmail - gets a session from elasticache by the email address.
+// Returns cache.ErrSessionNotFound if a session with the specified email does not exist.
 func (c *ElasticacheClient) GetByEmail(email string) (*session.Session, error) {
 	if email == "" {
 		return nil, ErrEmptySessionEmail

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,8 +1,0 @@
-package errors
-
-import "errors"
-
-var (
-	SessionNotFound = errors.New("session not found")
-	SessionExpired = errors.New("session has expired")
-)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -8,6 +8,26 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+func TestNew(t *testing.T) {
+	Convey("New should return expected error if email address is empty", t, func() {
+		s, err := New("")
+		So(err, ShouldEqual, EmailEmptyErr)
+		So(s, ShouldBeNil)
+	})
+
+	Convey("New should return valid session if email address is not empty", t, func() {
+		s, err := New("test@test.com")
+
+		So(err, ShouldBeNil)
+		So(s.Email, ShouldEqual, "test@test.com")
+		So(s.ID, ShouldNotBeEmpty)
+		So(s.LastAccessed, ShouldNotBeNil)
+		So(s.Start, ShouldNotBeNil)
+		So(s.Start, ShouldEqual, s.LastAccessed)
+	})
+
+}
+
 func TestSession_MarshalJSON(t *testing.T) {
 
 	Convey("Given valid session", t, func() {
@@ -31,8 +51,8 @@ func TestSession_MarshalJSON(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			Convey("Then session JSON has the expected field values", func() {
-				expectedStartVal := start.Format(dateTimeFMT)
-				expectedLastAccessedVal := lastAccess.Format(dateTimeFMT)
+				expectedStartVal := start.Format(DateTimeFMT)
+				expectedLastAccessedVal := lastAccess.Format(DateTimeFMT)
 
 				assertJSONFieldValue("id", "123", jsonMap)
 				assertJSONFieldValue("email", "test@test.com", jsonMap)
@@ -40,6 +60,59 @@ func TestSession_MarshalJSON(t *testing.T) {
 				assertJSONFieldValue("last_accessed", expectedLastAccessedVal, jsonMap)
 			})
 		})
+	})
+}
+
+func TestSession_UnmarshalJSON(t *testing.T) {
+	Convey("Should unmarshal valid session from JSON", t, func() {
+		input, err := New("test@ons.gov.uk")
+		So(err, ShouldBeNil)
+
+		jsonBytes, err := json.Marshal(input)
+		So(err, ShouldBeNil)
+
+		var output Session
+		err = json.Unmarshal(jsonBytes, &output)
+		So(err, ShouldBeNil)
+
+		So(input, ShouldResemble, &output)
+	})
+
+	Convey("Should return expected error is session.Start is blank/empty ", t, func() {
+		input := `{"id":"123","email":"test@ons.gov.uk","last_accessed":"2021-02-02T11:51:48.300Z"}`
+
+		var output Session
+		err := json.Unmarshal([]byte(input), &output)
+		So(err, ShouldEqual, StartEmptyErr)
+	})
+
+	Convey("Should return expected error is session.Start is blank/empty ", t, func() {
+		input := `{"id":"123","email":"test@ons.gov.uk","start":"2021-02-02T11:51:48.300Z"}`
+
+		var output Session
+		err := json.Unmarshal([]byte(input), &output)
+		So(err, ShouldEqual, LastAccessedEmptyErr)
+
+		err = json.Unmarshal([]byte(input), &output)
+		if err != nil {
+
+		}
+	})
+
+	Convey("Should return expected error if session.Start invalid time value", t, func() {
+		input := `{"id":"123","email":"test@ons.gov.uk","start":"bob", "last_accessed":"2021-02-02T11:51:48.300Z"}`
+
+		var output Session
+		err := json.Unmarshal([]byte(input), &output)
+		So(err.Error(), ShouldStartWith, "error parsing session.Start as time.Time value")
+	})
+
+	Convey("Should return expected error if session.Start invalid time value", t, func() {
+		input := `{"id":"123","email":"test@ons.gov.uk","start":"2021-02-02T11:51:48.300Z", "last_accessed":"wibble"}`
+
+		var output Session
+		err := json.Unmarshal([]byte(input), &output)
+		So(err.Error(), ShouldStartWith, "error parsing session.LastAccessed as time.Time value")
 	})
 }
 


### PR DESCRIPTION
- Updated cacheClient to return specific `Session Not Found` error when session is not found in cache.
- Updated API handler to check for new error type and return the appropriate status code.
- Updated unit tests.
- Delete unused code.
- Added custom UnmarshalJSON func + unit tests